### PR TITLE
v1.2.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad-react",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Medopad's ESLint configuration for React.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint-plugin-jest": "19.0.x"
   },
   "peerDependencies": {
-    "eslint-config-medopad": "1.1.x"
+    "eslint-config-medopad": "^2.0.0"
   },
   "devDependencies": {
     "mocha": "^3.0.0",


### PR DESCRIPTION
v1.2.0 release notes:

- Base config update
- It is now allowed to use later versions of base config without updating React config
