### PR TITLE
v1.2.1 release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+# Editor configuration
+.editorconfig
+
+# Travis CI setup
+.travis.yml
+
+# Current package's ESLint config
+.eslintrc.js
+
+# Tests
+*.test.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Medopad's ESLint configuration for React.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
v1.2.1 release notes:

- No more support for Node v5 (only v6 and v7)
- Certain files are now ignored for the final package release
