### PR TITLE
Make sure JSX boolean values are always set

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,5 +5,10 @@ module.exports = {
   extends: './index.js',
   parserOptions: {
     sourceType: 'script'
+  },
+  rules: {
+    'node/no-unsupported-features': ['error', {
+      ignores: ['modules']
+    }]
   }
 }

--- a/index.js
+++ b/index.js
@@ -12,5 +12,8 @@ module.exports = {
     'react',
     'jsx-a11y',
     'jest'
-  ]
+  ],
+  rules: {
+    'react/jsx-boolean-value': ['error', 'always']
+  }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -1,3 +1,4 @@
+const CLIEngine = require('eslint').CLIEngine
 const should = require('should')
 const config = require('./')
 
@@ -23,6 +24,28 @@ describe('Medopad\'s ESLint configuration for React', () => {
 
     config.plugins.forEach((plugin) => {
       (() => require.resolve(`eslint-plugin-${plugin}`)).should.not.throw()
+    })
+  })
+
+  describe('Rules', () => {
+    const cli = new CLIEngine({
+      configFile: 'index.js'
+    })
+
+    it('should validate `react/jsx-boolean-value`', () => {
+      const code = 'import React from \'react\'\n'
+
+      should(cli.executeOnText(
+        code + 'React.render(<input required={true} />)\n'
+      ).errorCount).equal(0)
+
+      should(cli.executeOnText(
+        code + 'React.render(<input required={false} />)\n'
+      ).errorCount).equal(0)
+
+      should(cli.executeOnText(
+        code + 'React.render(<input required />)\n'
+      ).errorCount).equal(1)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
+    "eslint": "3.19.x",
     "eslint-config-standard-react": "4.3.x",
     "eslint-plugin-react": "6.10.x",
     "eslint-plugin-jsx-a11y": "4.0.x",
@@ -30,6 +31,7 @@
     "eslint-config-medopad": "^2.0.0"
   },
   "devDependencies": {
+    "react": "^15.5.0",
     "mocha": "^3.0.0",
     "should": "^11.2.0"
   },


### PR DESCRIPTION
New rule: `react/jsx-boolean-value` - will error the code, when JSX attributes don't have boolean values set.

## Example

Invalid JSX:

```jsx
const MyTask = <Task personal />
```

Valid JSX:

```jsx
const MyTask = <Task personal={true} />
```