### PR TITLE
v2.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "eslint": "3.19.x",
-    "eslint-config-standard-react": "4.3.x",
+    "eslint-config-standard-react": "5.0.x",
     "eslint-plugin-react": "6.10.x",
     "eslint-plugin-jsx-a11y": "4.0.x",
     "eslint-plugin-jest": "19.0.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad-react",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Medopad's ESLint configuration for React.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
v2.0.0 release notes:

- New rule: `react/jsx-boolean-value` (see [pull request](https://github.com/Medopad/eslint-config-medopad-react/pull/7) for an example)
- Current package is now being linted when running tests
- Major update of `eslint-config-standard-react`
