### PR TITLE
Adapt to lodash mainstream library

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,9 @@
 const CLIEngine = require('eslint').CLIEngine
 const should = require('should')
+
+const forEach = require('lodash').forEach
+const startsWith = require('lodash').startsWith
+
 const config = require('./')
 
 describe('Medopad\'s ESLint configuration for React', () => {
@@ -16,13 +20,13 @@ describe('Medopad\'s ESLint configuration for React', () => {
   })
 
   it('should have all required modules listed as dependencies', () => {
-    config.extends.forEach((config) => {
-      if (!config.startsWith('plugin')) {
+    forEach(config.extends, (config) => {
+      if (!startsWith(config, 'plugin')) {
         (() => require.resolve(`eslint-config-${config}`)).should.not.throw()
       }
     })
 
-    config.plugins.forEach((plugin) => {
+    forEach(config.plugins, (plugin) => {
       (() => require.resolve(`eslint-plugin-${plugin}`)).should.not.throw()
     })
   })

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "eslint-plugin-jest": "20.0.x"
   },
   "peerDependencies": {
-    "eslint-config-medopad": "^2.0.0"
+    "eslint-config-medopad": "^3.0.0",
+    "lodash": "~4.17.0"
   },
   "devDependencies": {
     "react": "^15.5.0",


### PR DESCRIPTION
Config is now being adapted to a new version of base configuration, that has [lodash](https://lodash.com) added as a mainstream library.