### PR TITLE
v3.1.0 release

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ node_js:
   - 8
 
 before_script:
-  - npm install eslint-config-medopad
+  - npm install eslint-config-medopad --no-save
 
 deploy:
   provider: npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad-react",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad-react",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Medopad's ESLint configuration for React.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
v3.1.0 release notes:

- Node v8 is now supported
- Dependencies are now locked (for npm v5 only)
- Adaptation to `lodash` mainstream library
