### PR TITLE
v3.4.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad-react",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Medopad's ESLint configuration for React.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -22,19 +22,19 @@
     "npm": ">=5.0.0"
   },
   "dependencies": {
-    "eslint": "^4.1.0",
+    "eslint": "^4.4.0",
     "eslint-config-standard-react": "^5.0.0",
     "eslint-plugin-jest": "^20.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.0",
-    "eslint-plugin-react": "^7.0.0"
+    "eslint-plugin-react": "^7.2.0"
   },
   "peerDependencies": {
-    "eslint-config-medopad": "^3.2.0",
+    "eslint-config-medopad": "^3.6.0",
     "lodash": "^4.17.0"
   },
   "devDependencies": {
     "react": "^15.5.0",
-    "mocha": "^3.0.0",
+    "mocha": "^3.5.0",
     "should": "^11.2.0"
   },
   "scripts": {


### PR DESCRIPTION
v3.4.0 release notes:

- No more support for Node v7 (only v8)
- Packages are not locked anymore - only apps should lock dependencies
- Minor updates of dependencies
