### PR TITLE
Allow modules in syntax, error on any other unsupported feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,14 @@ module.exports = {
     'jest'
   ],
   rules: {
+    'node/no-unsupported-features': [
+      'error',
+      {
+        'ignores': [
+          'modules'
+        ]
+      }
+    ],
     'react/jsx-boolean-value': ['error', 'always']
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -36,6 +36,12 @@ describe('Medopad\'s ESLint configuration for React', () => {
       configFile: 'index.js'
     })
 
+    it('should validate `node/no-unsupported-features`', () => {
+      should(cli.executeOnText(
+        'export const test = \'This is only a test\'\n'
+      ).errorCount).equal(0)
+    })
+
     it('should validate `react/jsx-boolean-value`', () => {
       const code = 'import React from \'react\'\n'
 


### PR DESCRIPTION
New rule: `node/no-unsupported-features` ignores modules - will error the code, when unsupported Node feature is used, except modules.