### PR TITLE
Warn if closing bracket is not aligned with opening

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = {
         ]
       }
     ],
+    'react/jsx-closing-bracket-location': ['warn', 'tag-aligned'],
     'react/jsx-boolean-value': ['error', 'always']
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -42,6 +42,35 @@ describe('Medopad\'s ESLint configuration for React', () => {
       ).errorCount).equal(0)
     })
 
+    it('should validate `jsx-closing-bracket-location`', () => {
+      const code = 'import React from \'react\'\n'
+
+      should(cli.executeOnText(
+        code + 'React.render(<span style={{color: \'blue\'}}>Test</span>)\n'
+      ).warningCount).equal(0)
+
+      should(cli.executeOnText(
+        code +
+          'React.render(\n' +
+          '  <span\n' +
+          '    style={{color: \'blue\'}}\n' +
+          '  >\n' +
+          '    Test\n' +
+          '  </span>\n' +
+          ')\n'
+      ).warningCount).equal(0)
+
+      should(cli.executeOnText(
+        code +
+          'React.render(\n' +
+          '  <span\n' +
+          '    style={{color: \'blue\'}}>\n' +
+          '    Test\n' +
+          '  </span>\n' +
+          ')\n'
+      ).warningCount).equal(1)
+    })
+
     it('should validate `react/jsx-boolean-value`', () => {
       const code = 'import React from \'react\'\n'
 


### PR DESCRIPTION
New rule: `react/jsx-closing-bracket-location` - will warn, when closing bracket is not aligned with opening.